### PR TITLE
Polyfill spatnav step bug fix

### DIFF
--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -238,18 +238,18 @@ function focusNavigationHeuristics() {
   }
 
   /*
-  * Select the best candidate among candidates
-  * - Find the closet candidate from the starting point
-  * - If there are element having same distance, then select the one depend on DOM tree order.
+  * Get the filtered candidate among candidates
+  * - Get rid of the starting point from the focusables
+  * - Get rid of the elements which aren't in the direction from the focusables
   * reference: https://wicg.github.io/spatial-navigation/#select-the-best-candidate
   * @function
   * @param {Node} starting point
-  * @param {sequence<Node>} candidates
+  * @param {sequence<Node>} candidates - focusables
   * @param {SpatialNavigationDirection} direction
   * @param {Node} container
-  * @returns {Node} the best candidate
+  * @returns {sequence<Node>} filtered candidates
   */
-  function selectBestCandidate(currentElm, candidates, dir, container) {
+  function filteredCandidates(currentElm, candidates, dir, container) {
     let originalContainer = getSpatnavContainer(currentElm);
     let filteredcandidates = [];
     let eventTargetRect;
@@ -277,7 +277,22 @@ function focusNavigationHeuristics() {
           filteredcandidates.push(candidates[i]);
       }
 
-    candidates = filteredcandidates;
+    return filteredcandidates;
+  }
+
+  /*
+  * Select the best candidate among candidates
+  * - Find the closet candidate from the starting point
+  * - If there are element having same distance, then select the one depend on DOM tree order.
+  * reference: https://wicg.github.io/spatial-navigation/#select-the-best-candidate
+  * @function
+  * @param {Node} starting point
+  * @param {sequence<Node>} candidates
+  * @param {SpatialNavigationDirection} direction
+  * @param {Node} container
+  * @returns {Node} the best candidate
+  */
+  function selectBestCandidate(currentElm, candidates, dir, container) {
     let bestCandidate;
     let elementsSameDistance = [];
     let minDistance = Number.POSITIVE_INFINITY;
@@ -307,7 +322,7 @@ function focusNavigationHeuristics() {
     let minDistanceElement = undefined;
     let minDistance = Number.POSITIVE_INFINITY;
 
-    if(candidates) {
+    if(Array.isArray(candidates)) {
       for (let i = 0; i < candidates.length; i++) {
         let tempMinDistance = getInnerDistance(eventTargetRect, candidates[i].getBoundingClientRect(), dir);
 

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -78,7 +78,7 @@ function focusNavigationHeuristics() {
     // 6
     // Let container be the nearest ancestor of eventTarget
     let container = getSpatnavContainer(eventTarget);
-    let parentContainer = container.parentElement;
+    let parentContainer = getSpatnavContainer(container);
 
     // The container is IFRAME
     if (!parentContainer) {
@@ -122,7 +122,8 @@ function focusNavigationHeuristics() {
             }
           }
           else {
-            container = getSpatnavContainer(container);
+            container = parentContainer;
+            parentContainer = getSpatnavContainer(parentContainer);
           }
         }
       }

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -43,12 +43,15 @@ function focusNavigationHeuristics() {
   function navigate(dir) {
     // spatial navigation steps
 
+    // 1
     const startingPoint = findStartingPoint();
 
     // 2 Optional step, not handled
 
+    // 3
     let eventTarget = startingPoint;
 
+    // 4
     if (eventTarget === document || eventTarget === document.documentElement) {
       eventTarget = document.body || document.documentElement;
     }

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -198,46 +198,6 @@ function focusNavigationHeuristics() {
   };
 
   /*
-   * Find SpatNav Outside Element :
-   * Find the closest element from the current focused element,
-   * among the siblings of the container
-   */
-  function spatNavSearchOutside(element, dir) {
-    let container = getSpatnavContainer(element);
-    let parentContainer = getSpatnavContainer(container);
-    let candidates, bestCandidate;
-
-    console.log('spatnav outside');
-
-    candidates = findCandidates(parentContainer);
-
-    // Let bestCandidate be the result of selecting the best candidate within candidates in direction starting from eventTarget
-    bestCandidate = selectBestCandidate(element, candidates, dir, parentContainer);
-
-    // If there isn't any candidate outside of the container,
-    //  If the container is browsing context, focus will move to the container
-    // Otherwise, focus will stay as it is.
-    if (!bestCandidate && !isScrollContainer(container) && !SpatNavAPI.isCSSSpatNavContain(container)) {
-      bestCandidate = window;
-
-      if ( window.location !== window.parent.location ) {
-        // The page is in an iframe
-        bestCandidate = window.parent;
-      }
-    }
-
-    // If there isn't any candidate outside of the container and container is css spatnav container,
-    // search outside of the container again
-    if (!bestCandidate && SpatNavAPI.isCSSSpatNavContain(container)) {
-      let recursivespatNavSearchOutside = spatNavSearchOutside(container, dir);
-      if (recursivespatNavSearchOutside)
-        bestCandidate = recursivespatNavSearchOutside;
-    }
-
-    return bestCandidate;
-  }
-
-  /*
   * Get the filtered candidate among candidates
   * - Get rid of the starting point from the focusables
   * - Get rid of the elements which aren't in the direction from the focusables


### PR DESCRIPTION
Bug related to getting out of the container when there isn't any candidate.
Major changes are:
- Add 'filteredCandidates' function which is related to https://github.com/WICG/spatial-navigation/issues/62
   -  The function which excludes the starting point and the element that isn't in the direction from candidates
- Get rid of 'spatNavSearchOutside' which won't be used