### PR TITLE
Rewrite the Polyfill's readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository consists of the basic description for the spatial navigation, la
 
 You're welcome to contribute! If you have something to say for the spatial navigation, please kindly put it on [issues](https://github.com/WICG/spatial-navigation/issues) of this repository or send it via [email](mailto://lgewst@gmail.com). Let's make the Web to be extensible for the several industries!
 
+An [experimental Polyfill](./polyfill/) is available.
+
 ## Overview
 **Spatial navigation (aka Spatnav)** is the ability to navigate between focusable elements based on their position within a structured document. Spatial navigation is often called 'directional navigation' which enables four(4) directional navigation. Users are usually familiar with the 2-way navigation using tab key for the forward direction and shift+tab key for the backward direction, but not familiar with the 4-way navigation using arrow keys.
 

--- a/explainer.md
+++ b/explainer.md
@@ -11,6 +11,8 @@ such as pressing the <code class="key">Shift</code> key together with arrow keys
 This ability to move around the page directionally is called <strong>spatial navigation</strong>
 (or <strong>spatnav</strong> for short).
 
+An [experimental Polyfill](./polyfill/) is available.
+
 ## What are we going to solve?
 
 ### Supporting spatial navigation on a web page by default

--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -1,73 +1,96 @@
-#### 2018.4.6. updated
-#### Reference: https://wicg.github.io/spatial-navigation/
+# Spatial Navigation Polyfill
 
-# Spatial Navigation (Polyfill version 1)
-## Features
-1. Spatial Navigation Processing model
-    - Not using focus delegation model
-    - Not using enter key
+## What is this?
 
-2. JS API
-    - getSpatnavContainer()
-    - focusableAreas(optional FocusableAreasOptions arg)
-    - spatNavSearch(SpatNavSearchOptions arg)
+This is a JavaScript implementation of the [Spatial Navigation Specification](https://wicg.github.io/spatial-navigation/).
 
-## Definition
-* Starting point
-  - The element gaining the focus when spatial navigation is triggered.
-* Focusable
-  - Condition
-    - Browsing context (document, iframe)
-    - Element with tabIndex
-    - Scrollable region (a.k.a. Scroll Container)
-* Container
-  - Condition
-    - document
-    - Scroll Container
-      - The element not having 'visible' and 'clip' for CSS overflow property
-  - NOTE: Container is not always focusable
+It enables users to navigate the page using the arrow keys of the keyboard (or remote control, or game pad…),
+instead of (or in addition to)
+the <code class="key">Tab</code> key,
+the mouse cursor,
+or the touch screen.
 
-* Candidates
-  - Elements which are possible to get the focus within the container of currently focused element when there is an input of SpatNav.
-  - Reference: https://wicg.github.io/spatial-navigation/#find-focusable-areas
+Depending on the content and layout of the page,
+pressing one of the directional keys
+will either move the focus in that direction,
+or scroll the page, as appropriate.
 
-* Best Candidate
-  - An element which will gain the focus.
-  - An element which has the shortest distance among candidates.
-  - If there are multiple candidates which have the same distance, the best candidate is decided in order of DOM tree.
-  - Reference: https://wicg.github.io/spatial-navigation/#select-the-best-candidate
+For more details, see [the specification](https://wicg.github.io/spatial-navigation/)
+or [its explainer document](https://wicg.github.io/spatial-navigation/explainer.html).
 
-## Core Function
-### focusNavigationHeuristics()
-- Summary: Load SpatNav Polyfill
-- Syntax
-  - Parameter: N/A
-  - Return: N/A
+## Why use the Polyfill
 
-### spatNavSearch()
-- Summary: Run the spatial navigation step and find the best candidate which will gain the focus.
-- Syntax
-  - Parameter: direction
-  - Return: best candidate
-- Reference: https://wicg.github.io/spatial-navigation/#spatial-navigation-steps
+Eventually, we expect spatial navigation to be natively supported by browsers.
+However, this is not yet the case.
 
-### focusingController()
-- Summary: Decide focus behavior triggered by the directional input.
-- Syntax
-  - Parameter: bestCandidate, event, direction
-  - Return: N/A
+Until then, authors who wish to experiment with providing this feature to their users
+can include this polyfill in their page.
 
-## Main Logic
-### Inital Stage
-1. focusNavigationHeuristics()    (spatnav-utils.js)
-2. findStartingPoint(activeElement, null, null)            (spatnav-heuristic.js)
-3. focusingController(bestCandidate, event, direction)           (spatnav-heuristic.js)
+It can also be used for people interested in reviewing the specification
+it order to test the behavior it defines in various situations.
 
-### SpatNav Input
-1. Keydown Event                  (spatnav-heuristic.js)
-2. spatNavSearch(direction)       (spatnav-heuristic.js)
-3. focusingController(bestCandidate, event, direction)           (spatnav-heuristic.js)
+## Current Status
 
-# To Do
-## Future Implementation
-  - NavigationEvent (<code>navbeforefocus</code>, <code>navbeforescroll</code>, <code>navnotarget</code>)
+The polyfill is not yet complete.
+It roughly matches the specification
+but does not yet follow it closely,
+and has a number of known issues.
+
+See [the list of open bugs](https://github.com/wicg/spatial-navigation/issues?q=is%3Aissue+is%3Aopen+label%3Atopic%3Apolyfill) in github.
+
+## How to Use
+
+### Including the Polyfill in a page
+
+Include the following code in your web page,
+and the polyfill will be included,
+enabling spatial navigation.
+
+```html
+<script src="https://wicg.github.io/spatial-navigation/polyfill/spatnav-heuristic.js"></script>
+<script src="https://wicg.github.io/spatial-navigation/polyfill/spatnav-api.js"></script>
+<script>focusNavigationHeuristics();</script>
+```
+
+Users can now user the keyboard's arrow keys to navigate the page.
+
+### Using the APIs
+
+The spatial navigation specification defines several JavaScript [events](https://wicg.github.io/spatial-navigation/#events-navigationevent) and [APIs](https://wicg.github.io/spatial-navigation/#js-api).
+Using these is not necessary to use the polyfill,
+and users can start using the arrow keys as soon as the polyfill is included,
+but they can be convenient for authors who wish to override the default behavior in some cases.
+See the specification for more details.
+
+Following [the guidance from the W3C Technical Architecture Group](https://www.w3.org/2001/tag/doc/polyfills/#don-t-squat-on-proposed-names-in-speculative-polyfills),
+the polyfill provides these features under alternative names,
+to avoid interfering with the standardization process.
+
+| Standard Name | Polyfill Name |
+|-|-|
+| navbeforefocus | navbeforefocusPolyfill |
+| navbeforescroll | navbeforescrollPolyfill |
+| navnotarget | navnotargetPolyfill |
+| spatNavSearch() | spatNavSearchPolyfill() |
+| navigate() | navigatePolyfill() |
+| getSpatnavContainer() | *not implemented yet* |
+| focusableAreas() | *not implemented yet* |
+
+
+## Usage in automated tests
+
+Automated tests for the specification are written assuming standard syntax.
+In order to be able to use the Polyfill to run those tests,
+it is possible to load it in a special mode
+where it uses the standard names for the APIs and Events,
+unlike what is described in section [#using-the-apis].
+
+**It is recommended not to use this option
+for purposes other than runing the automated tests of the specication**.
+
+````html
+<script>var spatnavPolyfillOptions = {"standardName": "true" };</script>
+<script src="../polyfill/spatnav-heuristic.js"></script>
+<script src="../polyfill/spatnav-api.js"></script>
+<script>focusNavigationHeuristics();</script>
+```


### PR DESCRIPTION
Don't duplicate information found in the specification, and instead
focus on what the polyfill itself is, how to use it, and what its status
is.