### PR TITLE
Polyfill match api syntax

### DIFF
--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -89,8 +89,7 @@ unlike what is described in section [#using-the-apis].
 for purposes other than runing the automated tests of the specication**.
 
 ````html
-<script>var spatnavPolyfillOptions = {"standardName": "true" };</script>
 <script src="../polyfill/spatnav-heuristic.js"></script>
 <script src="../polyfill/spatnav-api.js"></script>
-<script>focusNavigationHeuristics();</script>
+<script>focusNavigationHeuristics({"standardName": "true" });</script>
 ````

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -389,7 +389,9 @@ function focusNavigationHeuristics(spatnavPolyfillOptions) {
   * Find focusable elements within the container
   * reference: https://wicg.github.io/spatial-navigation/#dom-element-focusableareas
   * @function
-  * @param {Node} container
+  * @param {FocusableAreasOptions} option
+  *         dictionary FocusableAreasOptions {FocusableAreaSearchMode mode;};
+  *         enum FocusableAreaSearchMode {"visible", "all"};
   * @returns {sequence<Node>} focusable areas
   */
   function focusableAreas(option) {
@@ -397,8 +399,7 @@ function focusNavigationHeuristics(spatnavPolyfillOptions) {
     let children = [];
     let container = this;
 
-    if (!option)
-      option = 'visible';
+    option = option || {'mode': 'visible'};
 
     if (container.childElementCount > 0) {
       if (!container.parentElement)
@@ -422,10 +423,10 @@ function focusNavigationHeuristics(spatnavPolyfillOptions) {
       }
     }
 
-    if (option === 'all') {
+    if (option.mode === 'all') {
       return focusables;
     }
-    else if (option === 'visible') {
+    else if (option.mode === 'visible') {
       return findVisibles(focusables);
     }
   }


### PR DESCRIPTION
- Match the syntax of Element APIs with Spec
  - `Element.focusableAreas`, `Element.getSpatnavContainer`
  - Get rid of `findCandidates` function which isn't used.
- Change the way of setting the standard syntax option