### PR TITLE
Polyfill container handle bug

### DIFF
--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -376,13 +376,13 @@ function focusNavigationHeuristics(spatnavPolyfillOptions) {
   * @returns {Node} container
   */
   function getSpatnavContainer() {
-    if (!this.parentElement) return this; // if element==HTML
+    if (!this.parentElement) return null; // if element==HTML
 
     let container = this.parentElement;
 
     while(!isContainer(container)) {
       container = container.parentElement;
-      if (!container) return this; // if element==HTML
+      if (!container) return null;
     }
 
     return container;


### PR DESCRIPTION
There was the bug related to the iframe element, especially when the focus moves out of it.
The reasons for this bug were:
- The result of getSpatNavContainer() for iframe element or document element was itself.
   - This should be the closet spatnav container or null.
- There wasn't proper handling for searching the candidates after the focus moves out of the iframe.

Fixes #80