### PR TITLE
Polyfill recursively find candidates

### DIFF
--- a/demo/sample/api_spatnav_contain.html
+++ b/demo/sample/api_spatnav_contain.html
@@ -20,7 +20,7 @@
       </h4>
       <button class="box" style="top:100px; left:20px;"></button>
       <button class="box" style="top:98px; left:180px;"></button>
-      <div class="container c1" tabindex="0" style="position: relative; left:110px; width:500px; height:200px; overflow-x: scroll;">
+      <div class="container c1" tabindex="-1" style="position: relative; left:110px; width:500px; height:200px; overflow-x: scroll;">
         <button class="box b2" style="top:78px; left:25px;"></button>
         <button class="box b2" style="top:78px; left:120px;"></button>
           <div class="container c2" style="position: relative; left:110px; width:250px; height:100px; --spatial-navigation-contain: contain;">

--- a/demo/sample/api_spatnav_contain.html
+++ b/demo/sample/api_spatnav_contain.html
@@ -6,12 +6,10 @@
     <meta name="application-name" content="Spatial Navigation Container">
     <meta name="author" content="Jihye Hong">
     <meta name="description" content="By default, spatial navigation container (a.k.a. spatnav container) are established by the viewport of a browsing context and scroll containers. Also, an element becomes spatnav container if it is specified with 'spatial-navigation-contain' CSS Property.">
-
     <link rel="stylesheet" href="spatnav-style.css">
     <script src="spatnav-utils.js"></script>
     <script src="../../polyfill/spatnav-heuristic.js"></script>
     <script src="../../polyfill/spatnav-api.js"></script>
-
   </head>
   <body>
     <div style="width:600px; height: 400px; padding: 20px;">

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -430,12 +430,10 @@ function focusNavigationHeuristics(spatnavPolyfillOptions) {
         if (isFocusable(thisElement)) {
           focusables.push(thisElement);
         }
-        else {
-          const recursiveFocusables = thisElement.focusableAreas(option);
+        const recursiveFocusables = thisElement.focusableAreas(option);
 
-          if (Array.isArray(recursiveFocusables) && recursiveFocusables.length) {
-            focusables = focusables.concat(recursiveFocusables);
-          }
+        if (Array.isArray(recursiveFocusables) && recursiveFocusables.length) {
+          focusables = focusables.concat(recursiveFocusables);
         }
       }
     }
@@ -621,7 +619,7 @@ function focusNavigationHeuristics(spatnavPolyfillOptions) {
 
   /**
   * isFocusable :
-  * Whether this element is focusable.
+  * Whether this element is focusable with spatnav.
   * check1. Whether the element is the browsing context (document, iframe)
   * check2. The value of tabIndex is ">= 0"
   * check3. Whether the element is disabled or not.


### PR DESCRIPTION
Currently, the spec defines that finding candidates from the set of all the focusable areas that are descendants of a container.
But the polyfill didn't work like it.

This PR solves the difference, and fixes https://github.com/WICG/spatial-navigation/issues/63