### PR TITLE
Make compatible keydown event handler in polyfill

### DIFF
--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -54,6 +54,18 @@ enabling spatial navigation.
 
 Users can now user the keyboard's arrow keys to navigate the page.
 
+### Handling <code>keydown</code> event
+In the polyfill, <a href="https://www.w3.org/TR/DOM-Level-3-Events/#event-type-keydown"><code>keydown</code> event</a> triggers the spatial navigation.
+Also, the <code>keydown</code> event handler is attached to the window object.
+
+We recommend to use it with the polyfill as below:
+
+* If you want to use the <code>keydown</code> event handler for other usages besides the spatial navigation,
+   * attach the event handler on the children of window object
+   or
+   * call the event handler during the capturing phase of the event.
+* If you don't want the <code>keydown</code> event work with the spatial navigation, call <code>preventDefault()</code> for it.
+
 ### Using the APIs
 
 The spatial navigation specification defines several JavaScript [events](https://wicg.github.io/spatial-navigation/#events-navigationevent) and [APIs](https://wicg.github.io/spatial-navigation/#js-api).

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -25,19 +25,21 @@ function focusNavigationHeuristics(spatnavPolyfillOptions) {
    * If arrow key pressed, get the next focusing element and send it to focusing controller
    */
   window.addEventListener('keydown', function(e) {
-    let focusNavigableArrowKey = {'left': true, 'up': true, 'right': true, 'down': true};
-    const eventTarget = document.activeElement;
-    const dir = ARROW_KEY_CODE[e.keyCode];
+    if (!e.defaultPrevented) {
+      let focusNavigableArrowKey = {'left': true, 'up': true, 'right': true, 'down': true};
+      const eventTarget = document.activeElement;
+      const dir = ARROW_KEY_CODE[e.keyCode];
 
-    // Edge case (text input, area) : Don't move focus, just navigate cursor in text area
-    if ((eventTarget.nodeName === 'INPUT') || eventTarget.nodeName === 'TEXTAREA')
-      focusNavigableArrowKey = handlingEditableElement(e);
+      // Edge case (text input, area) : Don't move focus, just navigate cursor in text area
+      if ((eventTarget.nodeName === 'INPUT') || eventTarget.nodeName === 'TEXTAREA')
+        focusNavigableArrowKey = handlingEditableElement(e);
 
-    if (focusNavigableArrowKey[dir]) {
-      e.preventDefault();
-      navigate(dir);
+      if (focusNavigableArrowKey[dir]) {
+        e.preventDefault();
+        navigate(dir);
+      }
+      startingPosition = null;
     }
-    startingPosition = null;
   });
 
   /**

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -24,7 +24,7 @@ function focusNavigationHeuristics(spatnavPolyfillOptions) {
    * keydown EventListener :
    * If arrow key pressed, get the next focusing element and send it to focusing controller
    */
-  document.addEventListener('keydown', function(e) {
+  window.addEventListener('keydown', function(e) {
     let focusNavigableArrowKey = {'left': true, 'up': true, 'right': true, 'down': true};
     const eventTarget = document.activeElement;
     const dir = ARROW_KEY_CODE[e.keyCode];


### PR DESCRIPTION
This PR is about the usage of keydown event handler in the polyfill.

- The polyfill assume that the keydown event triggers the spatial navigation
- In the polyfill, the keydown event handler is called on the window object.
Depending on those points, made an update in spatnav-heuristic.js.

Above defined usages of keydown event in polyfill can cause some compatibility issue when the authors try to manage the event on their own.
Therefore, added the guideline to avoid the issue.