### PR TITLE
Add the browser support to the polyfill README file

### DIFF
--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -18,7 +18,7 @@ or scroll the page, as appropriate.
 For more details, see [the specification](https://wicg.github.io/spatial-navigation/)
 or [its explainer document](https://wicg.github.io/spatial-navigation/explainer.html).
 
-## Why use the Polyfill
+## Why Use the Polyfill
 
 Eventually, we expect spatial navigation to be natively supported by browsers.
 However, this is not yet the case.
@@ -30,6 +30,36 @@ It can also be used for people interested in reviewing the specification
 it order to test the behavior it defines in various situations.
 
 ## Current Status
+
+### Browser Support
+With the polyfill, the Spatial Navigation has been tested and known to work in the following browsers:
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://raw.github.com/alrra/browser-logos/39.2.2/src/chrome/chrome_48x48.png" alt="Chrome"><br>
+      49+
+    </td>
+    <td align="center">
+      <img src="https://raw.github.com/alrra/browser-logos/39.2.2/src/firefox/firefox_48x48.png" alt="Firefox"><br>
+      61+
+    </td>
+    <td align="center">
+      <img src="https://raw.github.com/alrra/browser-logos/39.2.2/src/safari/safari_48x48.png" alt="Safari"><br>
+      11.1+
+    </td>
+    <td align="center">
+      <img src="https://raw.github.com/alrra/browser-logos/39.2.2/src/edge/edge_48x48.png" alt="Edge"><br>
+      17+
+    </td>
+    <td align="center">
+      <img src="https://raw.github.com/alrra/browser-logos/39.2.2/src/opera/opera_48x48.png" alt="Opera"><br>
+      36+
+    </td>
+  </tr>  
+</table>
+
+### Remaining Issues
 
 The polyfill is not yet complete.
 It roughly matches the specification
@@ -54,7 +84,7 @@ enabling spatial navigation.
 
 Users can now user the keyboard's arrow keys to navigate the page.
 
-### Handling browser events
+### Handling Browser Events
 In the polyfill, <a href="https://www.w3.org/TR/DOM-Level-3-Events/#event-type-keydown"><code>keydown</code> event</a> and <a href="https://www.w3.org/TR/DOM-Level-3-Events/#event-type-mouseup"><code>mouseup</code> event</a> are used for the spatial navigation.
 The event handlers of those are attached to the window object.
 


### PR DESCRIPTION
Add the browser support status about the polyfill.
- Test the polyfill on the several PC browsers. (Chrome, Firefox, Safari, IE, Edge, Opera)
- Note: The latest version of IE doesn't support the polyfill.