### PR TITLE
Modify the way to set the spatial navigation starting point

### DIFF
--- a/demo/sample/heuristic_non_scrollable_iframe.html
+++ b/demo/sample/heuristic_non_scrollable_iframe.html
@@ -12,7 +12,7 @@
 	<script src="../../polyfill/spatnav-heuristic.js"></script>
 </head>
 <body>
-	<iframe src="heuristic_non_scrollable_iframe_element.html" tabindex="0" class="container c2"></iframe>
+	<iframe src="heuristic_non_scrollable_iframe_element.html" class="container c2"></iframe>
 	<div tabindex="0" class="box b1" style="left: 70px; top: -180px;"></div>
 	<div tabindex="0" class="box b1" style="left: 180px; top: -120px;"></div>
 	<div tabindex="0" class="box b1" style="left: 20px; top: -90px;"></div>

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -68,9 +68,9 @@
           navigate(dir);
 
           spatNavManager.startingPosition = null;
-        }      
+        }
       }
-    
+
       if (e.keyCode === TAB_KEY_CODE)
         spatNavManager.startingPosition = null;
     });
@@ -97,19 +97,25 @@
 
     // 1
     let startingPoint = findStartingPoint();
+    let eventTarget = null;
+    let elementFromPosition = null;
 
     // 2 Optional step, UA defined starting point
     if (spatNavManager.startingPosition) {
-      const elementFromPosition = document.elementFromPoint(spatNavManager.startingPosition.xPosition, spatNavManager.startingPosition.yPosition);
-      
-      if (startingPoint.contains(elementFromPosition))
-        startingPoint = elementFromPosition;
-      
-      spatNavManager.startingPosition = null;
+      elementFromPosition = document.elementFromPoint(spatNavManager.startingPosition.xPosition, spatNavManager.startingPosition.yPosition);
     }
 
-    // 3
-    let eventTarget = startingPoint;
+    if (elementFromPosition && startingPoint.contains(elementFromPosition)) {
+      startingPoint = spatNavManager.startingPosition;
+      spatNavManager.startingPosition = null;
+
+      // 3
+      eventTarget = elementFromPosition;
+    }
+    else {
+      // 3
+      eventTarget = startingPoint;
+    }
 
     // 4
     if (eventTarget === document || eventTarget === document.documentElement) {
@@ -311,7 +317,7 @@
     // find the best candidate within startingPoint
     if (candidates && candidates.length > 0) {
       if ((isContainer(targetElement) || targetElement.nodeName === 'BODY') && !(targetElement.nodeName === 'INPUT')) {
-        if (candidates.every(x => targetElement.focusableAreas().includes(x))) { 
+        if (candidates.every(x => targetElement.focusableAreas().includes(x))) {
           // if candidates are contained in the targetElement, then the focus moves inside the targetElement
           bestCandidate = selectBestCandidateFromEdge(targetElement, candidates, dir);
         }
@@ -321,9 +327,9 @@
       }
       else {
         bestCandidate = selectBestCandidate(targetElement, candidates, dir);
-      }    
+      }
     }
-    
+
     return bestCandidate;
   }
 
@@ -648,7 +654,7 @@
     }
   }
 
-  /** 
+  /**
   * isOverflow
   * Whether this element is overflow or not
   * @function
@@ -1116,7 +1122,7 @@
   }
 
   window.addEventListener('load', function() {
-    
+
     // load SpatNav polyfill
     focusNavigationHeuristics();
   });

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -105,8 +105,11 @@
 
     // 3-2 : the mouse clicked position will be come the starting point
     if (spatNavManager.startingPosition) {
-      eventTarget = document.elementFromPoint(spatNavManager.startingPosition.xPosition, spatNavManager.startingPosition.yPosition);
-
+      const elementFromPosition = document.elementFromPoint(spatNavManager.startingPosition.xPosition, spatNavManager.startingPosition.yPosition);
+      
+      if (eventTarget.contains(elementFromPosition))
+        eventTarget = elementFromPosition;
+      
       spatNavManager.startingPosition = null;
     }
 

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -737,7 +737,6 @@
       return false;
     else
       return ((!element.parentElement) ||
-          (element.nodeName === 'IFRAME') ||
           (element.tabIndex >= 0) ||
           (isScrollable(element) && isOverflow(element)));
   }

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -96,14 +96,14 @@
     // spatial navigation steps
 
     // 1
-    const startingPoint = findStartingPoint();
+    let startingPoint = findStartingPoint();
 
     // 2 Optional step, UA defined starting point
     if (spatNavManager.startingPosition) {
       const elementFromPosition = document.elementFromPoint(spatNavManager.startingPosition.xPosition, spatNavManager.startingPosition.yPosition);
       
-      if (eventTarget.contains(elementFromPosition))
-        eventTarget = elementFromPosition;
+      if (startingPoint.contains(elementFromPosition))
+        startingPoint = elementFromPosition;
       
       spatNavManager.startingPosition = null;
     }

--- a/polyfill/spatnav-heuristic.js
+++ b/polyfill/spatnav-heuristic.js
@@ -78,6 +78,7 @@
     /**
     * mouseup EventListener :
     * If the mouse click a point in the page, the point will be the starting point.
+    * *NOTE: Let UA set the spatial navigation starting point based on click
     */
     document.addEventListener('mouseup', function(e) {
       spatNavManager.startingPosition = {xPosition: e.clientX, yPosition: e.clientY};
@@ -97,13 +98,7 @@
     // 1
     const startingPoint = findStartingPoint();
 
-    // 2 Optional step, not handled
-    // UA defined starting point
-
-    // 3
-    let eventTarget = startingPoint;
-
-    // 3-2 : the mouse clicked position will be come the starting point
+    // 2 Optional step, UA defined starting point
     if (spatNavManager.startingPosition) {
       const elementFromPosition = document.elementFromPoint(spatNavManager.startingPosition.xPosition, spatNavManager.startingPosition.yPosition);
       
@@ -112,6 +107,9 @@
       
       spatNavManager.startingPosition = null;
     }
+
+    // 3
+    let eventTarget = startingPoint;
 
     // 4
     if (eventTarget === document || eventTarget === document.documentElement) {


### PR DESCRIPTION
There was a difference between the spec and polyfill in the way of setting the spatial navigation starting point. (a.k.a. spatnav starting point)
- AS-IS: 
The spatnav starting point can be set even if the user clicks the outside area of the currently focused element.
- TO-BE (which matches with the spec):
But this isn't the spec says.
The spatnav starting point can be set only if the user clicks an element which is inside the currently focused element.

NOTE: The polyfill assumes that the UA could set the spatnav starting point to the position of the user's click if the user clicks on the document contents.

This PR fixes the difference.
Related github issue: https://github.com/WICG/spatial-navigation/issues/68


