### PR TITLE
Change to painting order for elements with equal distance

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -42,6 +42,9 @@ spec: css2; urlPrefix: https://drafts.csswg.org/css2/
     urlPrefix: box.html
         type: dfn;
             text: border box; url: #x14
+    urlPrefix: zindex.html
+        type: dfn;
+            text: painting order; url: #painting-order
 </pre>
 <pre class=link-defaults>
 spec:html; type:method; for:HTMLOrSVGElement; text:focus()
@@ -1174,7 +1177,12 @@ follow the following steps:
             * left edge is closest to the left edge of <var>insideArea</var> if <var>D</var> is <code>right</code>
         2. If <var>closest subset</var> contains a single item,
             return that item,
-            else return the first item of <var>closest subset</var> in document order
+            else return the first item of <var>closest subset</var> in document order,
+            unless its [=boundary box=] overlaps with the [=boundary box=] of an other item
+            and that item is higher in the CSS [=painting order=].
+            In that case, return that item instead,
+            unless it too is overlapped with another higher item, recursively.
+
     * Else
         1. Set <var>candidates</var> be the subset of its items
             whose <a>boundary box</a>'s geometric center is within the closed half plane
@@ -1203,6 +1211,12 @@ follow the following steps:
                 <dd>The square root of the area of intersection between the <a>boundary boxes</a> of <var>candidate</var> and <var>starting point</var>
             </dl>
         3. Return the item of the <var>candidates</var> set that has the smallest <var>distance</var>.
+            If several have the same distance,
+            return the first one in document order,
+            unless its [=boundary box=] overlaps with the [=boundary box=] of an other item at the same distance,
+            and that item is higher in the CSS [=painting order=].
+            In that case, return that item instead,
+            unless it too is overlapped with another higher item at the same distance, recursively.
 
 
 </div>


### PR DESCRIPTION
Closes #121


index.html is not regenerated from index.bs in this patch. That should be done after the merge.