### PR TITLE
Allow cancelling of scrollIntoView

### DIFF
--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -269,8 +269,13 @@
       const container = bestCandidate.getSpatialNavigationContainer();
 
       // Scrolling container or document when the next focusing element isn't entirely visible
-      if (isScrollContainer(container) && !isEntirelyVisible(bestCandidate))
-        bestCandidate.scrollIntoView();
+      if (isScrollContainer(container) && !isEntirelyVisible(bestCandidate)) {
+        createSpatNavEvents('beforescroll', bestCandidate, null, dir);
+
+        if (!navbeforescrollPrevented) {
+          bestCandidate.scrollIntoView();
+        }
+      }
 
       // When bestCandidate is a focusable element and not a container : move focus
       /*


### PR DESCRIPTION
This builds upon #156 by making it possible to prevent `focusingController` from scrolling the best candidate into view.

The following screen capture shows the problem in detail where horizontally scrolling a container and focusing a candidate outside the viewport triggers `scrollIntoView` that vertically scrolls the viewport to the upper edge of the target element.

![kapture 2019-02-27 at 10 38 19](https://user-images.githubusercontent.com/12807/53480608-d4609a80-3a7b-11e9-8f60-4e6f7a048a46.gif)

In this case it would be desirable to prevent the default behaviour by cancelling the `navbeforescroll` event and manually performing a horizontal-only scroll.