### PR TITLE
Fix the bug about navigation from the starting point

### DIFF
--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -147,14 +147,18 @@
 
     // 2 Optional step, UA defined starting point
     if (startingPoint) {
-      elementFromPosition = (document.elementFromPoint(startingPoint.x, startingPoint.y)).getSpatialNavigationContainer();
+      // if there is a starting point, set eventTarget as the element from position for getting the spatnav container
+      elementFromPosition = document.elementFromPoint(startingPoint.x, startingPoint.y);
     }
 
-    // 3
-    if (elementFromPosition && searchOrigin.contains(elementFromPosition)) {
-      eventTarget = elementFromPosition;
-    } else {
+    // 3 use starting point
+    // 1) starting point is inside the spatnav container
+    // 2) starting point is inside the non-focusable element
+    if ((searchOrigin === elementFromPosition) && !isContainer(searchOrigin)) {
       eventTarget = searchOrigin;
+      startingPoint = null;
+    } else {
+      eventTarget = elementFromPosition;
     }
 
     // 4

--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -142,23 +142,24 @@
 
     // 1
     const searchOrigin = findSearchOrigin();
-    let eventTarget = null;
+    let eventTarget = searchOrigin;
+
     let elementFromPosition = null;
 
     // 2 Optional step, UA defined starting point
     if (startingPoint) {
       // if there is a starting point, set eventTarget as the element from position for getting the spatnav container
       elementFromPosition = document.elementFromPoint(startingPoint.x, startingPoint.y);
-    }
 
-    // 3 use starting point
-    // 1) starting point is inside the spatnav container
-    // 2) starting point is inside the non-focusable element
-    if ((searchOrigin === elementFromPosition) && !isContainer(searchOrigin)) {
-      eventTarget = searchOrigin;
-      startingPoint = null;
-    } else {
-      eventTarget = elementFromPosition;
+       // 3 use starting point
+      // 1) starting point is inside the spatnav container
+      // 2) starting point is inside the non-focusable element
+
+      if (elementFromPosition && (searchOrigin === elementFromPosition) && !isContainer(searchOrigin)) {
+        startingPoint = null;
+      } else {
+        eventTarget = elementFromPosition;
+      }
     }
 
     // 4

--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -151,14 +151,14 @@
       // if there is a starting point, set eventTarget as the element from position for getting the spatnav container
       elementFromPosition = document.elementFromPoint(startingPoint.x, startingPoint.y);
 
-       // 3 use starting point
+      // Use starting point if the starting point isn't inside the focusable element (but not container)
+      // * Starting point is meaningfull when:
       // 1) starting point is inside the spatnav container
       // 2) starting point is inside the non-focusable element
-
-      if ((searchOrigin === elementFromPosition) && !isContainer(searchOrigin)) {
+      if (isFocusable(elementFromPosition) && !isContainer(elementFromPosition)) {
         startingPoint = null;
       } else {
-        eventTarget = elementFromPosition;
+        eventTarget = elementFromPosition.getSpatialNavigationContainer();
       }
     }
 

--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -155,7 +155,7 @@
       // 1) starting point is inside the spatnav container
       // 2) starting point is inside the non-focusable element
 
-      if (elementFromPosition && (searchOrigin === elementFromPosition) && !isContainer(searchOrigin)) {
+      if ((searchOrigin === elementFromPosition) && !isContainer(searchOrigin)) {
         startingPoint = null;
       } else {
         eventTarget = elementFromPosition;


### PR DESCRIPTION
* Bug: Double directional input is needed when there is a starting point.
* Reason: 
If the starting point exists inside the focusable element, 
the starting point isn't ignored and it becomes the search origin.
In this situation, the starting point must be ignored and the focusable element needs to be the search origin.
* Solution: Add the step for unsetting(making it `null`) the starting point only when it is inside the **focusable *element***.
   * NOTE: (Exceptional) If the starting point is inside the spatial navigation container, it needs to be maintained.