### PR TITLE
Minor Spelling Typo Fix

### DIFF
--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -132,7 +132,7 @@
   }
 
   /**
-   * Enable the author to trigger spatial navigation programatically, as if the user had done so manually.
+   * Enable the author to trigger spatial navigation programmatically, as if the user had done so manually.
    * @see {@link https://drafts.csswg.org/css-nav-1/#dom-window-navigate}
    * @function navigate
    * @param dir {SpatialNavigationDirection} - The directional information for the spatial navigation (e.g. LRUD)


### PR DESCRIPTION
A minor spelling typo fix on the word 'programatically' which ought to be spelled as 'programmatically'