### PR TITLE
 Apply new rule of spatialNavigationSearch() and getSpatialNavigation…

### DIFF
--- a/demo/sample/api_getSpatialNavigationContainer.html
+++ b/demo/sample/api_getSpatialNavigationContainer.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="application-name" content="API : getSpatialNavigationContainer()">
-    <meta name="author" content="jeonghee Ahn">
-    <meta name="description" content="element.getSpatialNavigationContainer() returns the nearest ancestor node which is the spatial navigation container.
+    <meta name="author" content="Jeonghee Ahn">
+    <meta name="description" content="element.getSpatialNavigationContainer() returns the nearest ancestor node which is the spatial navigation container of the element.
     You can check the result of element.getSpatialNavigationContainer() via <b>'background-color' and 'red outline' whenever focus is changed.</b>">
     <link rel="stylesheet" href="spatnav-style.css">
     <script src="spatnav-utils.js"></script>
@@ -18,7 +18,7 @@
       let previousBackground;
       const init = function(e) {
         console.log('========init=======');
-        const focusables = document.body.focusableAreas({'mode': 'all'});
+        const focusables = document.body.focusableAreas({mode: 'all'});
         console.log(focusables);
         for(focusable of focusables) {
           focusable.addEventListener('focus', function(e) {

--- a/demo/sample/api_spatialNavigationSearch.html
+++ b/demo/sample/api_spatialNavigationSearch.html
@@ -4,8 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="application-name" content="API :spatialNavigationSearch()">
-    <meta name="author" content="jeonghee Ahn">
+    <meta name="author" content="Jeonghee Ahn">
     <meta name="description" content="element.spatialNavigationSearch(SpatialNavigationSearchOptions) returns the best candidate which will gain the focus.
+    If there isn't any candidate, it returns `null`.<br>
     You can check the result of element.spatialNavigationSearch() as <b>'border-color' whenever the container gains the focus.</b>">
     <link rel="stylesheet" href="spatnav-style.css">
     <script src="spatnav-utils.js"></script>
@@ -21,7 +22,7 @@
       let redContainer;
       const init = function(e) {
         console.log('========init=======');
-        const focusables = document.body.focusableAreas({'mode': 'all'});
+        const focusables = document.body.focusableAreas({mode: 'all'});
 
         for(focusable of focusables) {
           focusable.addEventListener('focus', callSpatialNavigationSearch);

--- a/demo/sample/api_spatialNavigationSearch.html
+++ b/demo/sample/api_spatialNavigationSearch.html
@@ -49,9 +49,9 @@
           if (selectedOption === 'dir') {
             nextTarget = currentElement.spatialNavigationSearch(dir);
           } else if (selectedOption === 'candidates') {
-            nextTarget = currentElement.spatialNavigationSearch(dir, redBoxes);
+            nextTarget = currentElement.spatialNavigationSearch(dir, {candidates: redBoxes});
           } else if (selectedOption === 'container') {
-            nextTarget = currentElement.spatialNavigationSearch(dir, redBoxes, redContainer);
+            nextTarget = currentElement.spatialNavigationSearch(dir, {candidates: redBoxes, container: redContainer});
           }
 
           if(nextTarget && nextTarget.nodeName === 'BUTTON') {
@@ -66,11 +66,11 @@
           let selectedOptionString = {};
             for(dir of DIRECTION) {
               if (selectedOption === 'dir') {
-                selectedOptionString[dir] = `{dir: '${dir}'`;
+                selectedOptionString[dir] = `'${dir}'`;
               } else if (selectedOption === 'candidates') {
-                selectedOptionString[dir] = `{dir: '${dir}', candidates:[redBoxs]}`;
+                selectedOptionString[dir] = `'${dir}', {candidates: [redBoxs]}`;
               } else if (selectedOption === 'container') {
-                selectedOptionString[dir] = `{dir: '${dir}', candidates:[redBoxs], container:redContainer}`;
+                selectedOptionString[dir] = `'${dir}', {candidates: [redBoxs], container: redContainer}`;
               }
           }
 

--- a/tests/internal/api-test.html
+++ b/tests/internal/api-test.html
@@ -71,12 +71,6 @@
     }, `navigate() TC${testNum++}. #c1b1 button -> navigate('right') -> next Target should be #c2b2 button`);
 
     testRun(function() {
-      document.querySelector('#c2b1').focus();
-      window.navigate('right');
-      assert_equals(document.activeElement, document.querySelector('#c2b2'));
-    }, `navigate() TC${testNum++}. #c1b1 button -> navigate('right') -> next Target should be #c2b2 button`);
-
-    testRun(function() {
       document.querySelector('#c2b2').focus();
       window.navigate('right');
       assert_equals(document.activeElement, document.querySelector('#c1b3'));
@@ -142,98 +136,193 @@
 
     testRun(function() {
       let result = c1Container.spatialNavigationSearch('right');
+      assert_equals(result, document.querySelector('#b4'));
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right'); -> return element should be #b4 button`);
+
+    testRun(function() {
+      let result = c1Container.spatialNavigationSearch('right', {inside: true});
       assert_equals(result, document.querySelector('#c1b1'));
-    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right'); -> return element should be #c1b1 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right', {inside: true}); -> return element should be #c1b1 button`);
 
     testRun(function() {
       let result = c1Container.spatialNavigationSearch('left');
+      assert_equals(result, document.querySelector('#b1'));
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left'); -> return element should be #b1 button`);
+
+    testRun(function() {
+      let result = c1Container.spatialNavigationSearch('left', {inside: true});
       assert_equals(result, document.querySelector('#c1b3'));
-    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left'); -> return element should be #c1b3 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left', {inside: true}); -> return element should be #c1b3 button`);
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('right');
+      assert_equals(result, document.querySelector('#c1b3'));
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right'); -> return element should be #c1b3 button`);
+
+    testRun(function() {
+      let result = c2Container.spatialNavigationSearch('right', {inside: true});
       assert_equals(result, document.querySelector('#c2b1'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right'); -> return element should be #c2b1 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {inside: true}); -> return element should be #c2b1 button`);
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('left');
+      assert_equals(result, document.querySelector('#c1b1'));
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left'); -> return element should be #c1b1 button`);
+
+    testRun(function() {
+      let result = c2Container.spatialNavigationSearch('left', {inside: true});
       assert_equals(result, document.querySelector('#c2b2'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left'); -> return element should be #c2b2 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {inside: true}); -> return element should be #c2b2 button`);
 
     testRun(function() {
       let result = c1Container.spatialNavigationSearch('right', {candidates: c1Candidates});
+      assert_equals(result, null);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right', {candidates: c1Candidates}); -> return element should be null`);
+
+    testRun(function() {
+      let result = c1Container.spatialNavigationSearch('right', {candidates: c1Candidates, inside: true});
       assert_equals(result, document.querySelector('#c1b1'));
-    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right', {candidates: c1Candidates}); -> return element should be #c1b1 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right', {candidates: c1Candidates, inside: true}); -> return element should be #c1b1 button`);
 
     testRun(function() {
       let result = c1Container.spatialNavigationSearch('left', {candidates: c1Candidates});
+      assert_equals(result, null);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left', {candidates: c1Candidates}); -> return element should be null button`);
+
+    testRun(function() {
+      let result = c1Container.spatialNavigationSearch('left', {candidates: c1Candidates, inside: true});
       assert_equals(result, document.querySelector('#c1b3'));
-    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left', {candidates: c1Candidates}); -> return element should be #c1b3 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left', {candidates: c1Candidates, inside: true}); -> return element should be #c1b3 button`);
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('right', {candidates: c1Candidates});
+      assert_equals(result, document.querySelector('#c1b3'));
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c1Candidates}); -> return element should be #c1b3 button`);
+
+    testRun(function() {
+      let result = c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, inside: true});
       assert_equals(result, document.querySelector('#c2b1'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c1Candidates}); -> return element should be #c2b1 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, inside: true}); -> return element should be #c2b1 button`);
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('left', {candidates: c1Candidates});
+      assert_equals(result, document.querySelector('#c1b1'));
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates}); -> return element should be #c1b1 button`);
+
+    testRun(function() {
+      let result = c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, inside: true});
       assert_equals(result, document.querySelector('#c2b2'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates}); -> return element should be #c2b2 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, inside: true}); -> return element should be #c2b2 button`);
 
     testRun(function() {
       let result = c1Container.spatialNavigationSearch('right', {candidates: c2Candidates});
+      assert_equals(result, null);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right', {candidates: c2Candidates}); -> return element should be null`);
+
+    testRun(function() {
+      let result = c1Container.spatialNavigationSearch('right', {candidates: c2Candidates, inside: true});
       assert_equals(result, document.querySelector('#c2b1'));
-    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right', {candidates: c2Candidates}); -> return element should be #c2b1 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right', {candidates: c2Candidates, inside: true}); -> return element should be #c2b1 button`);
 
     testRun(function() {
       let result = c1Container.spatialNavigationSearch('left', {candidates: c2Candidates});
+      assert_equals(result, null);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left', {candidates: c2Candidates}); -> return element should be null`);
+
+    testRun(function() {
+      let result = c1Container.spatialNavigationSearch('left', {candidates: c2Candidates, inside: true});
       assert_equals(result, document.querySelector('#c2b2'));
-    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left', {candidates: c2Candidates}); -> return element should be #c2b2 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left', {candidates: c2Candidates, inside: true}); -> return element should be #c2b2 button`);
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('right', {candidates: c2Candidates});
+      assert_equals(result, null);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c2Candidates}); -> return element should be null`);
+
+    testRun(function() {
+      let result = c2Container.spatialNavigationSearch('right', {candidates: c2Candidates, inside: true});
       assert_equals(result, document.querySelector('#c2b1'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c2Candidates}); -> return element should be #c2b1 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c2Candidates, inside: true}); -> return element should be #c2b1 button`);
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('right', {candidates: c2Candidates, container: c1Container});
+      assert_equals(result, null);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c2Candidates, container: #c1}); -> return element should be null`);
+
+    testRun(function() {
+      let result = c2Container.spatialNavigationSearch('right', {candidates: c2Candidates, container: c1Container, inside: true});
       assert_equals(result, document.querySelector('#c2b1'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c2Candidates, container: #c1}); -> return element should be #c2b1 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c2Candidates, container: #c1, inside: true}); -> return element should be #c2b1 button`);
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('left', {candidates: c2Candidates});
+      assert_equals(result, null);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c2Candidates}); -> return element should be null`);
+
+    testRun(function() {
+      let result = c2Container.spatialNavigationSearch('left', {candidates: c2Candidates, inside: true});
       assert_equals(result, document.querySelector('#c2b2'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c2Candidates}); -> return element should be #c2b2 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c2Candidates, inside: true}); -> return element should be #c2b2 button`);
 
     testRun(function() {
       let result = c1Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: c2Container});
+      assert_equals(result, null);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: #c2}); -> return element should be null`);
+
+    testRun(function() {
+      let result = c1Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: c2Container, inside: true});
       assert_equals(result, document.querySelector('#c2b1'));
-    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: #c2}); -> return element should be #c2b1 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: #c2, inside: true}); -> return element should be #c2b1 button`);
 
     testRun(function() {
       let result = c1Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: c2Container});
+      assert_equals(result, null);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c2}); -> return element should be null`);
+
+    testRun(function() {
+      let result = c1Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: c2Container, inside: true});
       assert_equals(result, document.querySelector('#c2b2'));
-    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c2}); -> return element should be #c2b2 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c1Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c2, inside: true}); -> return element should be #c2b2 button`);
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: c1Container});
+      assert_equals(result, document.querySelector('#c1b3'));
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: #c1}); -> return element should be #c1b3 button`);
+
+    testRun(function() {
+      let result = c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: c1Container, inside: true});
       assert_equals(result, document.querySelector('#c2b1'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: #c1}); -> return element should be #c2b1 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: #c1, inside: true}); -> return element should be #c2b1 button`);
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: c1Container});
+      assert_equals(result, document.querySelector('#c1b1'));
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c1}); -> return element should be #c1b1 button`);
+
+    testRun(function() {
+      let result = c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: c1Container, inside: true});
       assert_equals(result, document.querySelector('#c2b2'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c1}); -> return element should be #c2b2 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c1, inside: true}); -> return element should be #c2b2 button`);
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: c2Container});
+      assert_equals(result, null);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: #c2}); -> return element should be null`);
+
+    testRun(function() {
+      let result = c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: c2Container, inside: true});
       assert_equals(result, document.querySelector('#c2b1'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: #c2}); -> return element should be #c2b1 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: #c2, inside: true}); -> return element should be #c2b1 button`);
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: c2Container});
+      assert_equals(result, null);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c2}); -> return element should be null`);
+
+    testRun(function() {
+      let result = c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: c2Container, inside: true});
       assert_equals(result, document.querySelector('#c2b2'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c2}); -> return element should be #c2b2 button`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c2, inside: true}); -> return element should be #c2b2 button`);
 
     testRun(function() {
       let result = document.querySelector('#b1').spatialNavigationSearch('right', {candidates: [document.querySelector('#b2')]});
@@ -256,11 +345,6 @@
     }, `spatialNavigationSearch() TC${testNum++}. #c2b2.spatialNavigationSearch('right', {container: #c1, outsideOnly: false}); -> return element should be #c1b3 button`);
 
     testRun(function() {
-      let result = document.querySelector('#c2b2').spatialNavigationSearch('right', {container: c1Container, outsideOnly: true});
-      assert_equals(result, document.querySelector('#c1b3'));
-    }, `spatialNavigationSearch() TC${testNum++}. #c2b2.spatialNavigationSearch('right', {container: #c1, outsideOnly: true}); -> return element should be #c1b3 button`);
-
-    testRun(function() {
       let result = document.querySelector('#c2b2').spatialNavigationSearch('right', {candidates: c1Candidates});
       assert_equals(result, null);
     }, `spatialNavigationSearch() TC${testNum++}. #c2b2.spatialNavigationSearch('right', {candidates: c1Candidates}); -> return element should be null`)
@@ -272,23 +356,13 @@
 
     testRun(function() {
       let result = c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: c2Container});
-      assert_equals(result, document.querySelector('#c2b2'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c2}); -> return element should be #c2b2 button`);
-
-    testRun(function() {
-      let result = c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: c1Container, outsideOnly: true});
-      assert_equals(result, document.querySelector('#c1b1'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c1, outsideOnly: true}); -> return element should be #c1b1 button`);
-
-    testRun(function() {
-      let result = c2Container.spatialNavigationSearch('right', {candidates: c2Candidates, container: c1Container, outsideOnly: true});
       assert_equals(result, null);
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c2Candidates, container: #c1, outsideOnly: true}); -> return element should be null`);
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c2}); -> return element should be null`);
 
     testRun(function() {
-      let result = c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: c1Container, outsideOnly: true});
-      assert_equals(result, document.querySelector('#c1b3'));
-    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('right', {candidates: c1Candidates, container: #c1, outsideOnly: true}); -> return element should be #c1b3 button`);
+      let result = c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: c2Container, inside: true});
+      assert_equals(result, document.querySelector('#c2b2'));
+    }, `spatialNavigationSearch() TC${testNum++}. c2Container.spatialNavigationSearch('left', {candidates: c1Candidates, container: #c2, inside: true}); -> return element should be #c2b2 button`);
 
     testNum = 1;
     testRun(function() {


### PR DESCRIPTION
Apply new rule of spatialNavigationSearch() and getSpatialNavigationContainer()
- `getSpatialNavigationContainer()` is not return itself.
- `spatialNavigationSearch()` has new option called 'inside'
- Fix internal TC for new `spatialNavigationSearch()`
- Fix `sample/api_spatialNavigationSearch.html` for `spatialNavigationSearch()`