### PR TITLE
Fix some polyfill bug and Add a TC for delegable container

### DIFF
--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -343,7 +343,7 @@
    *                                          Default value is 'visible'.
    * @returns {sequence<Node>} candidate elements within the container
    */
-  function getSpatialNavigationCandidates(container, option = {mode: 'visible'}) {
+  function getSpatialNavigationCandidates (container, option = {mode: 'visible'}) {
     let candidates = [];
 
     if (container.childElementCount > 0) {
@@ -358,10 +358,10 @@
           candidates.push(elem);
 
           if(!isContainer(elem) && elem.childElementCount) {
-            candidates = candidates.concat(getSpatialNavigationCandidates(elem, option = {mode: 'all'}));
+            candidates = candidates.concat(getSpatialNavigationCandidates(elem, {mode: 'all'}));
           }
         } else if (elem.childElementCount) {
-          candidates = candidates.concat(getSpatialNavigationCandidates(elem, option = {mode: 'all'}));
+          candidates = candidates.concat(getSpatialNavigationCandidates(elem, {mode: 'all'}));
         }
       }
     }
@@ -715,11 +715,6 @@
             }
           }
           else {
-            // avoiding when spatnav container with tabindex=-1
-            if (isFocusable(container)) {
-              eventTarget = container;
-            }
-
             container = parentContainer;
             currentOption = {candidates: getSpatialNavigationCandidates(container, {mode: option}), container};
 
@@ -1671,14 +1666,14 @@
         set keyMode(mode) { this._keymode = (['SHIFTARROW', 'ARROW', 'NONE'].includes(mode)) ? mode : 'ARROW'; },
         currentInterest,
         interest,
-        setStartingPoint: function (x, y) {startingPoint = (x && y) ? {x, y} : null}
+        setStartingPoint: function (x, y) {startingPoint = (x && y) ? {x, y} : null;}
       };
     else
       return {
         enableExperimentalAPIs,
         get keyMode() { return this._keymode ? this._keymode : 'ARROW'; },
         set keyMode(mode) { this._keymode = (['SHIFTARROW', 'ARROW', 'NONE'].includes(mode)) ? mode : 'ARROW'; },
-        setStartingPoint: function (x, y) {startingPoint = (x && y) ? {x, y} : null}
+        setStartingPoint: function (x, y) {startingPoint = (x && y) ? {x, y} : null;}
       };
   }
 

--- a/tests/internal/delegable-container-test2.html
+++ b/tests/internal/delegable-container-test2.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <meta charset="utf-8">
+  <title>Spatnav sanity check</title>
+  <script src="../../polyfill/spatial-navigation-polyfill.js"></script>
+
+  <link rel="stylesheet" href="../../demo/sample/spatnav-style.css">
+  <link rel="stylesheet" href="test.css">
+  <script src="test.js"></script>
+  <style>
+    h1 {
+      font-size: 20px;
+    }
+    .container {
+      width: 700px;
+      height: auto;
+    }
+    .note {
+      margin-top: 20px;
+      color: red;
+    }
+  </style>
+  </head>
+  <body onload="onload()">
+    <div style="width:800px; height: auto; padding: 20px;">
+      <div class="note">
+        All container is not focusable container.
+      </div>
+      <div class="container c1" style="--spatial-navigation-contain: delegable;">
+        <h1>
+          <a id="content1" href="">Content 1</a>
+        </h1>
+        <div>
+        This is <b>delegable container</b>.
+        <br>
+        When you press "down" key from "Menu6", this "Content 1" link will get focus.
+        </div>
+      </div>
+      <div class="container c2" style="padding-top:700px; --spatial-navigation-contain: delegable;">
+        <h1>
+          <a id="content2" href="">Content 2</a>
+        </h1>
+        <div>
+        This is <b>not delegable container</b>.
+        <br>
+        The "Content 2" link is closer than "Content 1" link to "Menu6". But the red container will first target because it is delegable container.
+        </div>
+      </div>
+    </div>
+  </body>
+  <script>
+  var onload = () => {
+    testInit();
+    // navigate() test
+    testRun(function() {
+      document.querySelector('#content1').focus();
+      window.navigate('down');
+      assert_equals(document.activeElement, document.querySelector('#content2'));
+    }, "delegable container TC1. #content1 -> navigate('down') -> next Target should be #content2 button. even though it is offscreen.");
+
+  }
+  </script>
+</html>


### PR DESCRIPTION
- Don't change event target when escaping focusable container.
- Fix bug about option.mode in getSpatialNavigationCandidates (Wrong assignment )
- Add missed semicolons.
- Delegable-container should delegate focus to child focusable element, even thourgh the child focusable element is offscreen.