### PR TITLE
fix exitPoint calculation

### DIFF
--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -1085,7 +1085,8 @@
     const points = {entryPoint: {x: 0, y: 0}, exitPoint:{x: 0, y: 0}};
 
     if (startingPoint) {
-      points.exitPoint = searchOrigin;
+      points.exitPoint.x = searchOrigin.left;
+      points.exitPoint.y = searchOrigin.top;
 
       switch (dir) {
       case 'left':


### PR DESCRIPTION
when searchOrigin value is the result of custom getBoundingClientRect it has no x and y props