### PR TITLE
Modify the condition of scroll container

### DIFF
--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -733,7 +733,10 @@
     const elementStyle = window.getComputedStyle(element, null);
     const overflowX = elementStyle.getPropertyValue('overflow-x');
     const overflowY = elementStyle.getPropertyValue('overflow-y');
-    return (overflowX !== 'visible' && overflowX !== 'clip') && (overflowY !== 'visible' && overflowY !== 'clip');
+
+    return ((overflowX !== 'visible' && overflowX !== 'clip' && isOverflow(element, 'left')) ||
+          (overflowY !== 'visible' && overflowY !== 'clip' && isOverflow(element, 'down'))) ?
+           true : false;
   }
 
   /**
@@ -1554,6 +1557,7 @@
 
     return {
       isContainer,
+      isScrollContainer,
       findCandidates: findTarget.bind(null, true),
       findNextTarget: findTarget.bind(null, false),
       getDistanceFromTarget: (element, candidateElement, dir) => {

--- a/tests/internal/scrollable-container-test.html
+++ b/tests/internal/scrollable-container-test.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang=en>
+  <meta charset="utf-8">
+  <title>Spatnav sanity check</title>
+  <script src="../../polyfill/spatial-navigation-polyfill.js"></script>
+  </script>
+  <link rel="stylesheet" href="../../demo/sample/spatnav-style.css">
+  <link rel="stylesheet" href="test.css">
+  <script src="test.js"></script>
+  <style>
+  #d {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+  }
+  </style>
+  <body onload="onload()">
+    <div id="c1" class="container" tabindex="0" style="width:600px; height:100px; overflow-y: scroll;">
+      <button id="c1b1" class="box" style="top: 50px; left: 100px;"></button>
+    </div>
+
+    <div id="c2" class="container" tabindex="0" style="width:600px; height:100px; overflow: auto;">
+        <button id="c2b1" class="box" style="top: 50px; left: 100px;"></button>
+    </div>
+
+    <div id="c3" class="container" tabindex="0" style="width:600px; height:100px; overflow: auto;">
+      <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+      <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+    </div>
+
+    <div id="c4" class="container" tabindex="0" style="width:600px; height:100px; overflow: scroll;">
+        <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+        <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+      </div>
+
+    <div id="c5" class="container" tabindex="0" style="width:600px; height:100px; overflow: hidden;">
+      <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+      <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+    </div>
+
+    <div id="c6" class="container" tabindex="0" style="width:600px; height:100px; overflow: clip;">
+      <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+      <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+    </div>
+
+    <div id="c7" class="container" tabindex="0" style="width:600px; height:100px; overflow: visible;">
+        <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+        <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+    </div>
+  </body>
+  <script>
+  var onload = () => {
+    window.__spatialNavigation__.enableExperimentalAPIs(true);
+    testInit();
+
+    let testNum = 1;
+    let containers = document.querySelectorAll('.container');
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[0]), false);
+    }, `isScrollContainer TC${testNum++}. not overflowing element with 'overflow: scroll' is not a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[1]), false);
+    }, `isScrollContainer TC${testNum++}. not overflowing element with 'overflow: auto' is not a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[2]), true);
+    }, `isScrollContainer TC${testNum++}. overflowing element with 'overflow: auto' is a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[3]), true);
+    }, `isScrollContainer TC${testNum++}. overflowing element with 'overflow: scroll' is a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[4]), true);
+    }, `isScrollContainer TC${testNum++}. overflowing element with 'overflow: hidden' is a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[5]), false);
+    }, `isScrollContainer TC${testNum++}. overflowing element with 'overflow: clip' is not a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[6]), false);
+    }, `isScrollContainer TC${testNum++}. overflowing element with 'overflow: visible' is not a scroll container`);
+  }
+  </script>
+</html>


### PR DESCRIPTION
* Modify the condition of scroll container with details below:
   * not overflowing element with any overflow property is not a scroll container
  * overflowing element with `overflow: hidden` is a scroll container
* Add test cases for the changes

This implementation also matches with CSS Overflow spec (https://drafts.csswg.org/css-overflow-3/#scroll-container).