### PR TITLE
Fix the behavior of `spatial-navigation-action: auto`

### DIFF
--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -167,14 +167,17 @@
       if (eventTarget.nodeName === 'IFRAME')
         eventTarget = eventTarget.contentDocument.body;
 
+      let bestInsideCandidate = null;
+
       // 5-2
       if (getCSSSpatNavAction(eventTarget) === 'scroll') {
         if (scrollingController(eventTarget, dir)) return;
       } else if (getCSSSpatNavAction(eventTarget) === 'focus') {
-        if (focusingController(eventTarget.spatialNavigationSearch(dir, {candidates: getSpatialNavigationCandidates(eventTarget, {mode: 'all'}), inside: true}), dir)) return;
+        bestInsideCandidate = eventTarget.spatialNavigationSearch(dir, {container: eventTarget, candidates: getSpatialNavigationCandidates(eventTarget, {mode: 'all'}), inside: true});
+        if (focusingController(bestInsideCandidate, dir)) return;
       } else if (getCSSSpatNavAction(eventTarget) === 'auto') {
-        if (focusingController(eventTarget.spatialNavigationSearch(dir, {inside: true}), dir)) return;
-        if (scrollingController(eventTarget, dir)) return;
+        bestInsideCandidate = eventTarget.spatialNavigationSearch(dir, {container: eventTarget, inside: true});
+        if (focusingController(bestInsideCandidate, dir) || scrollingController(eventTarget, dir)) return;
       }
     }
 

--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -733,7 +733,10 @@
     const elementStyle = window.getComputedStyle(element, null);
     const overflowX = elementStyle.getPropertyValue('overflow-x');
     const overflowY = elementStyle.getPropertyValue('overflow-y');
-    return (overflowX !== 'visible' && overflowX !== 'clip') && (overflowY !== 'visible' && overflowY !== 'clip');
+
+    return ((overflowX !== 'visible' && overflowX !== 'clip' && isOverflow(element, 'left')) ||
+          (overflowY !== 'visible' && overflowY !== 'clip' && isOverflow(element, 'down'))) ?
+           true : false;
   }
 
   /**
@@ -1554,6 +1557,7 @@
 
     return {
       isContainer,
+      isScrollContainer,
       findCandidates: findTarget.bind(null, true),
       findNextTarget: findTarget.bind(null, false),
       getDistanceFromTarget: (element, candidateElement, dir) => {

--- a/tests/internal/scrollable-container-test.html
+++ b/tests/internal/scrollable-container-test.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang=en>
+  <meta charset="utf-8">
+  <title>Spatnav sanity check</title>
+  <script src="../../polyfill/spatial-navigation-polyfill.js"></script>
+  </script>
+  <link rel="stylesheet" href="../../demo/sample/spatnav-style.css">
+  <link rel="stylesheet" href="test.css">
+  <script src="test.js"></script>
+  <style>
+  #d {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+  }
+  </style>
+  <body onload="onload()">
+    <div id="c1" class="container" tabindex="0" style="width:600px; height:100px; overflow-y: scroll;">
+      <button id="c1b1" class="box" style="top: 50px; left: 100px;"></button>
+    </div>
+
+    <div id="c2" class="container" tabindex="0" style="width:600px; height:100px; overflow: auto;">
+        <button id="c2b1" class="box" style="top: 50px; left: 100px;"></button>
+    </div>
+
+    <div id="c3" class="container" tabindex="0" style="width:600px; height:100px; overflow: auto;">
+      <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+      <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+    </div>
+
+    <div id="c4" class="container" tabindex="0" style="width:600px; height:100px; overflow: scroll;">
+        <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+        <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+      </div>
+
+    <div id="c5" class="container" tabindex="0" style="width:600px; height:100px; overflow: hidden;">
+      <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+      <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+    </div>
+
+    <div id="c6" class="container" tabindex="0" style="width:600px; height:100px; overflow: clip;">
+      <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+      <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+    </div>
+
+    <div id="c7" class="container" tabindex="0" style="width:600px; height:100px; overflow: visible;">
+        <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+        <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+    </div>
+  </body>
+  <script>
+  var onload = () => {
+    window.__spatialNavigation__.enableExperimentalAPIs(true);
+    testInit();
+
+    let testNum = 1;
+    let containers = document.querySelectorAll('.container');
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[0]), false);
+    }, `isScrollContainer TC${testNum++}. not overflowing element with 'overflow: scroll' is not a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[1]), false);
+    }, `isScrollContainer TC${testNum++}. not overflowing element with 'overflow: auto' is not a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[2]), true);
+    }, `isScrollContainer TC${testNum++}. overflowing element with 'overflow: auto' is a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[3]), true);
+    }, `isScrollContainer TC${testNum++}. overflowing element with 'overflow: scroll' is a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[4]), true);
+    }, `isScrollContainer TC${testNum++}. overflowing element with 'overflow: hidden' is a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[5]), false);
+    }, `isScrollContainer TC${testNum++}. overflowing element with 'overflow: clip' is not a scroll container`);
+
+    testRun(function() {
+      assert_equals(window.__spatialNavigation__.isScrollContainer(containers[6]), false);
+    }, `isScrollContainer TC${testNum++}. overflowing element with 'overflow: visible' is not a scroll container`);
+  }
+  </script>
+</html>

--- a/tests/internal/spatial-navigation-action-test.html
+++ b/tests/internal/spatial-navigation-action-test.html
@@ -45,23 +45,18 @@
     let c3Button2 = document.querySelector('#c3b2');
 
     testRun(function() {
-      let prevScrollPosition;
+      let prevScrollPosition = 0;
       container1.scrollTop = 0;
       c1Button1.focus();
 
       // scroll
       navigate('down');
       assert_equals(document.activeElement, c1Button1);
-      assert_not_equals(container1.scrollTop, 0);
-      prevScrollPosition = container1.scrollTop;
-
+      assert_not_equals(container1.scrollTop, prevScrollPosition);
+      
       // move focus to c1Button2
       navigate('down');
       assert_equals(document.activeElement, c1Button2);
-
-      // scroll
-      navigate('down');
-      assert_not_equals(container1.scrollTop, prevScrollPosition);
 
       // move focus to container2
       navigate('down');
@@ -70,7 +65,6 @@
     }, `--spatial-navigation-action TC${testNum++}. --spatial-navigation-action: auto; should perform scroll and move focus`);
 
     testRun(function() {
-      let prevScrollPosition;
       container1.scrollTop = 0;
       container2.focus();
 
@@ -80,7 +74,6 @@
     }, `--spatial-navigation-action TC${testNum++}. --spatial-navigation-action: focus; should perform move focus. when press down key on container1, c1Button1 should get focus.`);
 
     testRun(function() {
-      let prevScrollPosition;
       c2Button1.focus();
 
       // move focus to c2Button1


### PR DESCRIPTION
Test success with
* sample/api_spatial_navigation_action.html
* tests/internal/spatial-navigation-action-test.html
   * Modified this test case
* sample/heuristic_overflow_regions.html

Reason for the bug:
* Change of getSpatialNavigationContainer() wasn't considered