### PR TITLE
Make the overflowing element with 'overflow: hidden' cannot scroll by User Input

### DIFF
--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -223,7 +223,7 @@
       if (!createSpatNavEvents('beforefocus', bestCandidate, null, dir))
         return true;
 
-      bestCandidate.focus();
+      bestCandidate.focus({preventScroll:true});
       return true;
     }
 
@@ -741,6 +741,8 @@
 
   /**
    * Decide whether this element is scrollable or not.
+   * NOTE: If the value of 'overflow' is given to either 'visible', 'clip', or 'hidden', the element isn't scrollable.
+   *       If the value is 'hidden', the element can be only programmically scrollable. (https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden)
    * @function isScrollable
    * @param element {Node}
    * @param dir {SpatialNavigationDirection} - The directional information for the spatial navigation (e.g. LRUD)
@@ -759,11 +761,11 @@
           case 'left':
             /* falls through */
           case 'right':
-            return (overflowX !== 'visible' && overflowX !== 'clip');
+            return (overflowX !== 'visible' && overflowX !== 'clip' && overflowX !== 'hidden');
           case 'up':
             /* falls through */
           case 'down':
-            return (overflowY !== 'visible' && overflowY !== 'clip');
+            return (overflowY !== 'visible' && overflowY !== 'clip' && overflowY !== 'hidden');
           }
         }
         return false;

--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -211,9 +211,13 @@
     // When bestCandidate is found
     if (bestCandidate) {
       const container = bestCandidate.getSpatialNavigationContainer();
+      const elementStyle = window.getComputedStyle(container, null);
+      const overflowX = elementStyle.getPropertyValue('overflow-x');
+      const overflowY = elementStyle.getPropertyValue('overflow-y');
 
       // Scrolling container or document when the next focusing element isn't entirely visible
-      if (isScrollContainer(container) && !isEntirelyVisible(bestCandidate))
+      if (isScrollContainer(container) && !isEntirelyVisible(bestCandidate) && 
+          (overflowX !== 'hidden' || overflowY !== 'hidden'))
         bestCandidate.scrollIntoView();
 
       // When bestCandidate is a focusable element and not a container : move focus

--- a/tests/internal/scrollable-container-test.html
+++ b/tests/internal/scrollable-container-test.html
@@ -15,38 +15,51 @@
   }
   </style>
   <body onload="onload()">
-    <div id="c1" class="container" tabindex="0" style="width:600px; height:100px; overflow-y: scroll;">
+    <div id="c1" class="container" tabindex="0" style="width:600px; height:100px; overflow: scroll;">
+      overflow: scroll
       <button id="c1b1" class="box" style="top: 50px; left: 100px;"></button>
     </div>
 
     <div id="c2" class="container" tabindex="0" style="width:600px; height:100px; overflow: auto;">
-        <button id="c2b1" class="box" style="top: 50px; left: 100px;"></button>
+      overflow: auto
+      <button id="c2b1" class="box" style="top: 50px; left: 100px;"></button>
     </div>
 
     <div id="c3" class="container" tabindex="0" style="width:600px; height:100px; overflow: auto;">
+      overflow: auto
       <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
       <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+      <button id="c3b3" class="box" style="top: 150px; left: 100px;"></button>
     </div>
 
     <div id="c4" class="container" tabindex="0" style="width:600px; height:100px; overflow: scroll;">
-        <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
-        <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
-      </div>
-
-    <div id="c5" class="container" tabindex="0" style="width:600px; height:100px; overflow: hidden;">
+      overflow: scroll
       <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
       <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+      <button id="c3b3" class="box" style="top: 150px; left: 100px;"></button>
+    </div>
+
+    <div id="c5" class="container" tabindex="0" style="width:600px; height:100px; overflow: hidden;">
+      overflow: hidden
+      <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+      <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+      <button id="c3b3" class="box" style="top: 150px; left: 100px;"></button>
     </div>
 
     <div id="c6" class="container" tabindex="0" style="width:600px; height:100px; overflow: clip;">
+      overflow: clip
       <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
       <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+      <button id="c3b3" class="box" style="top: 150px; left: 100px;"></button>
     </div>
 
     <div id="c7" class="container" tabindex="0" style="width:600px; height:100px; overflow: visible;">
-        <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
-        <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+      overflow: visible
+      <button id="c3b1" class="box" style="top: 50px; left: 100px;"></button>
+      <button id="c3b2" class="box" style="top: 100px; left: 100px;"></button>
+      <button id="c3b3" class="box" style="top: 150px; left: 100px;"></button>
     </div>
+    <br><br>
   </body>
   <script>
   var onload = () => {


### PR DESCRIPTION
Don't allow scrolling by spatial navigation for the overflowing **_container_** with `overflow: hidden`.
* No scrolling down the **_container_** by directional input
* No scrolling into view when a partially visible element inside the **_container_** get the focus

Only the programmatic scroll (e.g: `element.scroll()`) can scroll this type of **_container_**.

Related to : https://github.com/WICG/spatial-navigation/issues/189