### PR TITLE
Find the proper best candidate when the focus moves inside the iframe

### DIFF
--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -166,9 +166,6 @@
 
       if (eventTarget.nodeName === 'IFRAME') {
         eventTarget = eventTarget.contentDocument.documentElement;
-
-        let candidates = getSpatialNavigationCandidates(eventTarget, {mode: 'visible'});
-        candidates.forEach(candidate => {console.log(candidate); }); 
       }
 
       let bestInsideCandidate = null;
@@ -511,7 +508,7 @@
     if (candidates) {
       for (let i = 0; i < candidates.length; i++) {
         const distance = distanceFunction(eventTargetRect, getBoundingClientRect(candidates[i]), dir);
-        
+
         // If the same distance, the candidate will be selected in the DOM order
         if (distance < minDistance) {
           minDistance = distance;

--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -164,9 +164,8 @@
     if ((isContainer(eventTarget) || eventTarget.nodeName === 'BODY') && !(eventTarget.nodeName === 'INPUT')) {
       container = eventTarget;
 
-      if (eventTarget.nodeName === 'IFRAME') {
+      if (eventTarget.nodeName === 'IFRAME')
         eventTarget = eventTarget.contentDocument.documentElement;
-      }
 
       let bestInsideCandidate = null;
 

--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -165,7 +165,7 @@
       container = eventTarget;
 
       if (eventTarget.nodeName === 'IFRAME') {
-        eventTarget = eventTarget.contentDocument.body;
+        eventTarget = eventTarget.contentDocument.documentElement;
 
         let candidates = getSpatialNavigationCandidates(eventTarget, {mode: 'visible'});
         candidates.forEach(candidate => {console.log(candidate); }); 

--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -494,14 +494,24 @@
    * @returns {Node} The candidate which is the closest one from the search origin
    */
   function getClosestElement(currentElm, candidates, dir, distanceFunction) {
-    const eventTargetRect = getBoundingClientRect(currentElm);
+    let eventTargetRect = null;
+    if (( window.location !== window.parent.location ) && (currentElm.nodeName === 'BODY' || currentElm.nodeName === 'HTML')) {
+      // If the eventTarget is iframe, then get rect of it based on its containing document
+      // Set the iframe's position as (0,0) because the rects of elements inside the iframe don't know the real iframe's position.
+      eventTargetRect = window.frameElement.getBoundingClientRect();
+      eventTargetRect.x = 0;
+      eventTargetRect.y = 0;
+    }
+    else 
+      eventTargetRect = currentElm.getBoundingClientRect();
+
     let minDistance = Number.POSITIVE_INFINITY;
     let minDistanceElements = [];
 
     if (candidates) {
       for (let i = 0; i < candidates.length; i++) {
         const distance = distanceFunction(eventTargetRect, getBoundingClientRect(candidates[i]), dir);
-
+        
         // If the same distance, the candidate will be selected in the DOM order
         if (distance < minDistance) {
           minDistance = distance;

--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -164,8 +164,12 @@
     if ((isContainer(eventTarget) || eventTarget.nodeName === 'BODY') && !(eventTarget.nodeName === 'INPUT')) {
       container = eventTarget;
 
-      if (eventTarget.nodeName === 'IFRAME')
+      if (eventTarget.nodeName === 'IFRAME') {
         eventTarget = eventTarget.contentDocument.body;
+
+        let candidates = getSpatialNavigationCandidates(eventTarget, {mode: 'visible'});
+        candidates.forEach(candidate => {console.log(candidate); }); 
+      }
 
       let bestInsideCandidate = null;
 

--- a/tests/internal/iframe-test.html
+++ b/tests/internal/iframe-test.html
@@ -47,6 +47,18 @@
       assert_not_equals(document.activeElement, iframeElement);
       assert_equals(document.activeElement, document.querySelector('#b4'));
     }, "iframe TC3. iframe -> iterate 'down' key -> focus should escape from iframe");
+
+    testRun(function() {
+      iframeElement.contentDocument.documentElement.scroll(0, iframeElement.contentDocument.documentElement.scrollHeight);
+      document.querySelector('#b4').focus();
+
+      let e = new KeyboardEvent("keydown", {bubbles : true, cancelable : true, keyCode : 40});
+      iframeElement.contentDocument.dispatchEvent(e);
+      window.navigate('up');
+      window.navigate('up');
+      assert_not_equals(document.activeElement, iframeElement);
+      assert_equals(document.activeElement, document.querySelector('#sub-b7'));
+    }, "iframe TC4. #b4 button -> iterate double 'up' key -> focus the most bottom element of iframe");
   }
   </script>
 </html>

--- a/tests/internal/iframe-test.html
+++ b/tests/internal/iframe-test.html
@@ -11,7 +11,7 @@
 </head>
 <body onload="onload()">
   <div tabindex="0" class="box b1" id="b1" style="left: 70px; top: 10px; margin-bottom: 20px;"></div>
-  <iframe src="iframe_sub.html" id="iframe-element" tabindex="0" class="container c2"></iframe>	
+  <iframe src="iframe_sub.html" id="iframe-element" tabindex="0" class="container c2"></iframe>
 	<div tabindex="0" class="box b1" id="b2" style="left: 120px; top: -150px;"></div>
 	<div tabindex="0" class="box b1" id="b3" style="left: 20px; top: -90px;"></div>
 	<div tabindex="0" class="box b1" id="b4" style="left: 190px; top: -20px;"></div>

--- a/tests/internal/iframe-test.html
+++ b/tests/internal/iframe-test.html
@@ -12,9 +12,9 @@
 <body onload="onload()">
   <div tabindex="0" class="box b1" id="b1" style="left: 70px; top: 10px; margin-bottom: 20px;"></div>
   <iframe src="iframe_sub.html" id="iframe-element" tabindex="0" class="container c2"></iframe>
-	<div tabindex="0" class="box b1" id="b2" style="left: 120px; top: -150px;"></div>
-	<div tabindex="0" class="box b1" id="b3" style="left: 20px; top: -90px;"></div>
-	<div tabindex="0" class="box b1" id="b4" style="left: 190px; top: -20px;"></div>
+  <div tabindex="0" class="box b1" id="b2" style="left: 120px; top: -150px;"></div>
+  <div tabindex="0" class="box b1" id="b3" style="left: 20px; top: -90px;"></div>
+  <div tabindex="0" class="box b1" id="b4" style="left: 190px; top: -20px;"></div>
 </body>
 
   <script>

--- a/tests/internal/iframe-test.html
+++ b/tests/internal/iframe-test.html
@@ -10,11 +10,11 @@
   <script src="test.js"></script>
 </head>
 <body onload="onload()">
-	<iframe src="iframe_sub.html" id="iframe-element" tabindex="0" class="container c2"></iframe>
-	<div tabindex="0" class="box b1" id="b1" style="left: 70px; top: -180px;"></div>
-	<div tabindex="0" class="box b1" id="b2" style="left: 180px; top: -120px;"></div>
+  <div tabindex="0" class="box b1" id="b1" style="left: 70px; top: 10px; margin-bottom: 20px;"></div>
+  <iframe src="iframe_sub.html" id="iframe-element" tabindex="0" class="container c2"></iframe>	
+	<div tabindex="0" class="box b1" id="b2" style="left: 120px; top: -150px;"></div>
 	<div tabindex="0" class="box b1" id="b3" style="left: 20px; top: -90px;"></div>
-	<div tabindex="0" class="box b1" id="b4" style="left: 190px; top: -50px;"></div>
+	<div tabindex="0" class="box b1" id="b4" style="left: 190px; top: -20px;"></div>
 </body>
 
   <script>
@@ -27,38 +27,39 @@
       window.navigate('up');
       assert_equals(document.activeElement, iframeElement);
       window.navigate('up');
-      assert_equals(document.activeElement, document.querySelector('#iframe-element'));
+      assert_equals(document.activeElement, iframeElement);
       assert_equals(iframeElement.contentDocument.activeElement, iframeElement.contentDocument.querySelector('#sub-b4'));
     }, "iframe TC1. b4 button -> navigate('up') -> next Target should be iframe element");
 
     testRun(function() {
-      iframeElement.contentDocument.querySelector('#sub-b8').focus();
+      iframeElement.contentDocument.querySelector('#sub-b7').focus();
       var e = new KeyboardEvent("keydown", {bubbles : true, cancelable : true, keyCode : 40});
       iframeElement.contentDocument.dispatchEvent(e);
       assert_equals(document.activeElement, document.querySelector('#b4'));
-    }, "iframe TC2. #sub-b8 button -> navigate('down') -> next Target should be #b4 element");
+    }, "iframe TC2. sub-b7 button -> iterate 'down' key -> focus should escape from iframe and next Target should be #b4 element");
 
     testRun(function() {
-      iframeElement.contentDocument.querySelector('#sub-b8').focus();
-      let e = new KeyboardEvent("keydown", {bubbles : true, cancelable : true, keyCode : 40});
-      iframeElement.contentDocument.dispatchEvent(e);
+      iframeElement.contentDocument.documentElement.scroll(0, 0);
+      document.querySelector('#b1').focus();
+
       window.navigate('down');
+      assert_equals(document.activeElement, iframeElement);
       window.navigate('down');
-      assert_not_equals(document.activeElement, iframeElement);
-      assert_equals(document.activeElement, document.querySelector('#b4'));
-    }, "iframe TC3. iframe -> iterate 'down' key -> focus should escape from iframe");
+      assert_equals(document.activeElement, iframeElement);
+      assert_equals(iframeElement.contentDocument.activeElement, iframeElement.contentDocument.querySelector('#sub-b1'));
+    }, "iframe TC4. b1 button -> iterate double 'down' key -> focus the most top element of iframe");
 
     testRun(function() {
       iframeElement.contentDocument.documentElement.scroll(0, iframeElement.contentDocument.documentElement.scrollHeight);
       document.querySelector('#b4').focus();
 
-      let e = new KeyboardEvent("keydown", {bubbles : true, cancelable : true, keyCode : 40});
-      iframeElement.contentDocument.dispatchEvent(e);
       window.navigate('up');
+      assert_equals(document.activeElement, iframeElement);
       window.navigate('up');
-      assert_not_equals(document.activeElement, iframeElement);
-      assert_equals(document.activeElement, document.querySelector('#sub-b7'));
-    }, "iframe TC4. #b4 button -> iterate double 'up' key -> focus the most bottom element of iframe");
+      assert_equals(document.activeElement, iframeElement);
+      assert_equals(iframeElement.contentDocument.activeElement, iframeElement.contentDocument.querySelector('#sub-b7'));
+      assert_not_equals(iframeElement.contentDocument.activeElement, iframeElement.contentDocument.querySelector('#sub-b4'));
+    }, "iframe TC4. b4 button -> iterate double 'up' key -> focus the most bottom element of iframe");
   }
   </script>
 </html>

--- a/tests/internal/iframe_sub.html
+++ b/tests/internal/iframe_sub.html
@@ -7,13 +7,12 @@
 	<script src="../../polyfill/spatial-navigation-polyfill.js"></script>
 </head>
 <body>
-	<div tabindex="0" class="box b3" id="sub-b1" style="left: 80px; top: 20px"></div>
+	<div tabindex="0" class="box b3" id="sub-b1" style="left: 80px; top: 10px"></div>
 	<div tabindex="0" class="box b3" id="sub-b2" style="left: 150px; top: 30px"></div>
 	<div tabindex="0" class="box b3" id="sub-b3" style="left: 20px; top: 70px"></div>
 	<div tabindex="0" class="box b3" id="sub-b4" style="left: 130px; top: 100px"></div>
-	<div tabindex="0" class="box b3" id="sub-b5" style="left: 100px; top: 120px"></div>
-	<div tabindex="0" class="box b3" id="sub-b6" style="left: 50px; top: 150px"></div>
-	<div tabindex="0" class="box b3" id="sub-b7" style="left: 90px; top: 160px"></div>
-	<div tabindex="0" class="box b3" id="sub-b8" style="left: 30px; top: 180px"></div>
+	<div tabindex="0" class="box b3" id="sub-b5" style="left: 50px; top: 150px"></div>
+	<div tabindex="0" class="box b3" id="sub-b6" style="left: 90px; top: 160px"></div>
+	<div tabindex="0" class="box b3" id="sub-b7" style="left: 30px; top: 180px"></div>
 </body>
 </html>


### PR DESCRIPTION
* Issue: Focus always goes to the top-most element when it moves inside the iframe not considering the scroll offset of the iframe)
* Solution: 
   1) Get the rect of iframe based on its containing document
   2) Set the iframe's position as (0,0) because the rects of elements inside the iframe don't know the real iframe's position.
* Added more test case for checking this update
