### PR TITLE
support contenteditable elements

### DIFF
--- a/polyfill/spatial-navigation-polyfill.js
+++ b/polyfill/spatial-navigation-polyfill.js
@@ -1571,7 +1571,7 @@
     const textSelection = eventTarget.hasAttribute('contenteditable') ? getTextSelection(eventTarget) : eventTarget;
     const startPosition = textSelection.selectionStart;
     const endPosition = textSelection.selectionEnd;
-    const textLength  = textSelection.textLength;
+    const textLength  = eventTarget.hasAttribute('contenteditable') ? textSelection.textLength : eventTarget.value.length;
     const focusNavigableArrowKey = {left: false, up: false, right: false, down: false};
 
     const dir = ARROW_KEY_CODE[e.keyCode];


### PR DESCRIPTION
The polyfill does not support contenteditable elements right now:
The cursor does not move with arrow keys with ARROW mode OR shift+<arrow key> does not do text selection with SHIFTARROW mode.
This change adds handling of contenteditable elements to the code which handles `input` and `textarea` elements.

Well.. my use case is pretty special, it may be, please consider if contenteditable support is needed.