### PR TITLE
chore: Fix typo in polyfill readme

### DIFF
--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -1,1 +1,1 @@
-This polyfill implementation follows the latest [Satial Navigation Spec](https://drafts.csswg.org/css-nav-1/)
+This polyfill implementation follows the latest [Spatial Navigation Spec](https://drafts.csswg.org/css-nav-1/)


### PR DESCRIPTION
A small typo slipped in the polyfill readme